### PR TITLE
feat: SerializableDictionary implements IReadOnlyDictionary<TKey, TValue>

### DIFF
--- a/Runtime/SerializableCollections/SerializableDictionary.cs
+++ b/Runtime/SerializableCollections/SerializableDictionary.cs
@@ -19,8 +19,8 @@
     /// }
     /// </code></example>
     [Serializable]
-    public class SerializableDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDictionary,
-        ISerializationCallbackReceiver, IDeserializationCallback, ISerializable
+    public class SerializableDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDictionary, IReadOnlyDictionary<TKey, TValue>,
+        ISerializationCallbackReceiver, IDeserializationCallback, ISerializable   
     {
         private Dictionary<TKey, TValue> _dict;
         [SerializeField] private TKey[] _keys;
@@ -47,6 +47,10 @@
         public bool IsSynchronized => ((IDictionary) _dict).IsSynchronized;
 
         public object SyncRoot => ((IDictionary) _dict).SyncRoot;
+
+        IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys => ((IReadOnlyDictionary<TKey, TValue>)_dict).Keys;
+
+        IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => ((IReadOnlyDictionary<TKey, TValue>)_dict).Values;
 
         public object this[object key]
         {


### PR DESCRIPTION
I like to use IReadOnlyDictionary types when passing around dictionaries that shouldn't be modified by the code that's receiving them, but SerializableDictionary didn't implement the interface. It was, however, a very *minor* addition, so I just went ahead and did that.

I... haven't done a lot of open-source contributions in the past, tbh, so I hope I haven't done anything wrong and I'm not stepping on any toes?

Anyway, the code should be pretty self-explanatory; I didn't really have to do much of anything to implement the interface. Just a small quality-of-life improvement for using the collection in certain programming patterns.