### PR TITLE
Fix incorrect editor style name for Unity 2022.3+

### DIFF
--- a/Runtime/Helpers/GUIHelper.cs
+++ b/Runtime/Helpers/GUIHelper.cs
@@ -5,8 +5,12 @@
     using UnityEngine;
 
     public static class GUIHelper
-    {
+    {                
+        #if UNITY_2022_3_OR_NEWER       
+        private static readonly GUIStyle _closeButtonStyle = GUI.skin.FindStyle("ToolbarSearchCancelButton");
+        #else        
         private static readonly GUIStyle _closeButtonStyle = GUI.skin.FindStyle("ToolbarSeachCancelButton");
+        #endif
 
         /// <summary>Draws the close button.</summary>
         /// <param name="buttonRect">Rect the button should be located in.</param>

--- a/Runtime/Helpers/GUIHelper.cs
+++ b/Runtime/Helpers/GUIHelper.cs
@@ -6,11 +6,7 @@
 
     public static class GUIHelper
     {                
-        #if UNITY_2022_3_OR_NEWER       
-        private static readonly GUIStyle _closeButtonStyle = GUI.skin.FindStyle("ToolbarSearchCancelButton");
-        #else        
-        private static readonly GUIStyle _closeButtonStyle = GUI.skin.FindStyle("ToolbarSeachCancelButton");
-        #endif
+        private static readonly GUIStyle _closeButtonStyle = FindCloseButtonStyle();
 
         /// <summary>Draws the close button.</summary>
         /// <param name="buttonRect">Rect the button should be located in.</param>
@@ -38,6 +34,17 @@
         /// <param name="viewRect">The rectangle used inside the scrollView.</param>
         public static ScrollView ScrollViewBlock(Rect position, ref Vector2 scrollPosition, Rect viewRect) => new ScrollView(position, ref scrollPosition, viewRect);
 
+        private static GUIStyle FindCloseButtonStyle()
+        {
+            // Name was changed in Unity 2023.2, 2021.3.28, 2022.3.1
+            GUIStyle style = GUI.skin.FindStyle("ToolbarSearchCancelButton");
+            if (style == null)
+            {
+                style = GUI.skin.FindStyle("ToolbarSeachCancelButton");
+            }
+            return style;
+        }
+        
         public readonly struct ScrollView : IDisposable
         {
             public ScrollView(Rect position, ref Vector2 scrollPosition, Rect viewRect)


### PR DESCRIPTION
In Unity 2022.3 they fixed typo in style name.
https://github.com/Unity-Technologies/UnityCsReference/commit/da51b77dce790fa867436bec018bfd56e464cec4#diff-d4e399fabac0c73f6f6580b4c4094492ab460619fb45fe621764230982beefd3

Closes #8 