### PR TITLE
Add support for unity 2022 and higher

### DIFF
--- a/Runtime/Helpers/GUIHelper.cs
+++ b/Runtime/Helpers/GUIHelper.cs
@@ -6,8 +6,11 @@
 
     public static class GUIHelper
     {
+#if UNITY_2023_2_OR_NEWER || UNITY_2021_3_28 || UNITY_2022_3_1
         private static readonly GUIStyle _closeButtonStyle = GUI.skin.FindStyle("ToolbarSearchCancelButton");
-
+#else
+        private static readonly GUIStyle _closeButtonStyle = GUI.skin.FindStyle("ToolbarSeachCancelButton");
+#endif
         /// <summary>Draws the close button.</summary>
         /// <param name="buttonRect">Rect the button should be located in.</param>
         /// <returns>Whether the button was pressed.</returns>

--- a/Runtime/Helpers/GUIHelper.cs
+++ b/Runtime/Helpers/GUIHelper.cs
@@ -6,7 +6,7 @@
 
     public static class GUIHelper
     {
-        private static readonly GUIStyle _closeButtonStyle = GUI.skin.FindStyle("ToolbarSeachCancelButton");
+        private static readonly GUIStyle _closeButtonStyle = GUI.skin.FindStyle("ToolbarSearchCancelButton");
 
         /// <summary>Draws the close button.</summary>
         /// <param name="buttonRect">Rect the button should be located in.</param>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.solidalloy.util",
-  "version": "1.40.0",
+  "version": "1.41.0",
   "displayName": "Solid Utilities",
   "description": "Different utilities that simplify development in Unity3D",
   "keywords": [


### PR DESCRIPTION
Unity changed styles names so In unity 2022 dropdown doesn't work.

[link](https://github.com/Unity-Technologies/InputSystem/pull/1730/files)

Closes https://github.com/SolidAlloy/SolidUtilities/issues/8