### PR TITLE
Fixed giving null assembly name when assembly is present.

### DIFF
--- a/Editor/Extensions/MonoScriptExtensions.cs
+++ b/Editor/Extensions/MonoScriptExtensions.cs
@@ -89,9 +89,13 @@
         /// </returns>
         [PublicAPI, NotNull] public static string GetAssemblyName(this MonoScript script)
         {
-            string assemblyName = script.Internal_GetAssemblyName();
+		    string assemblyName = script.Internal_GetAssemblyName();
             int lastDotIndex = assemblyName.LastIndexOf('.');
-            return lastDotIndex == -1 ? string.Empty : assemblyName.Substring(0, lastDotIndex);
+		    if(assemblyName == null || assemblyName == string.Empty)
+		    {
+				return string.Empty;
+		    }
+		    return lastDotIndex == -1 ? assemblyName : assemblyName.Substring(0, lastDotIndex);
         }
 
         private static string GetNamespaceName(this MonoScript asset)

--- a/Editor/Extensions/MonoScriptExtensions.cs
+++ b/Editor/Extensions/MonoScriptExtensions.cs
@@ -89,13 +89,13 @@
         /// </returns>
         [PublicAPI, NotNull] public static string GetAssemblyName(this MonoScript script)
         {
-		    string assemblyName = script.Internal_GetAssemblyName();
+	    string assemblyName = script.Internal_GetAssemblyName();
             int lastDotIndex = assemblyName.LastIndexOf('.');
-		    if(assemblyName == null || assemblyName == string.Empty)
-		    {
-				return string.Empty;
-		    }
-		    return lastDotIndex == -1 ? assemblyName : assemblyName.Substring(0, lastDotIndex);
+	    if(assemblyName == null || assemblyName == string.Empty)
+	    {
+		return string.Empty;
+	    }
+	    return lastDotIndex == -1 ? assemblyName : assemblyName.Substring(0, lastDotIndex);
         }
 
         private static string GetNamespaceName(this MonoScript asset)


### PR DESCRIPTION
Currently, as of unity 2022 (did not test any newer), if an assembly does not have a dot '.' in its name the function:
`GetAssemblyName(Args)` will return an empty string, instead of the assemblyName.

Instead, the method should only return an empty string if the assemblyName is empty/null, and return the assemblyName if the dotIndex is  -1 (else perform the string split)